### PR TITLE
Ensure that Azure SAS tokens are valid prior to the deployment and for two years.

### DIFF
--- a/cougar/terraform/assetStorageAccount.tf
+++ b/cougar/terraform/assetStorageAccount.tf
@@ -9,15 +9,15 @@ resource "azurerm_storage_account" "assetStorageAccount" {
 # Reference: https://adrianhall.github.io/typescript/2019/10/23/terraform-functions/
 
 resource "azurerm_storage_container" "assets" {
-    name = "assets"
-    storage_account_name = azurerm_storage_account.assetStorageAccount.name
-    container_access_type = "private"
+  name = "assets"
+  storage_account_name = azurerm_storage_account.assetStorageAccount.name
+  container_access_type = "private"
 }
 
 resource "azurerm_storage_blob" "cougar" {
-    name = "cougar.jpg"
-    storage_account_name = azurerm_storage_account.assetStorageAccount.name
-    storage_container_name = azurerm_storage_container.assets.name
-    type = "block"
-    source = "../assets/cougar.jpg"
+  name = "cougar.jpg"
+  storage_account_name = azurerm_storage_account.assetStorageAccount.name
+  storage_container_name = azurerm_storage_container.assets.name
+  type = "block"
+  source = "../assets/cougar.jpg"
 }

--- a/cougar/terraform/functionApp.tf
+++ b/cougar/terraform/functionApp.tf
@@ -2,7 +2,7 @@
 data "azurerm_storage_account_sas" "sas" {
   connection_string = "${azurerm_storage_account.functionStorageAccount.primary_connection_string}"
   https_only = true
-  formatdate("YYYY-MM-DD", timeadd(timestamp(), "-48h"))
+  start = formatdate("YYYY-MM-DD", timeadd(timestamp(), "-48h"))
   expiry = formatdate("YYYY-MM-DD", timeadd(timestamp(), "17520h"))
 
   resource_types {

--- a/cougar/terraform/functionApp.tf
+++ b/cougar/terraform/functionApp.tf
@@ -1,30 +1,33 @@
 # Reference: https://adrianhall.github.io/typescript/2019/10/23/terraform-functions/
 data "azurerm_storage_account_sas" "sas" {
-    connection_string = "${azurerm_storage_account.functionStorageAccount.primary_connection_string}"
-    https_only = true
-    start = formatdate("YYYY-MM-DD", timestamp())
-    expiry = formatdate("YYYY-MM-DD", timeadd(timestamp(), "24h"))
-    resource_types {
-        object = true
-        container = false
-        service = false
-    }
-    services {
-        blob = true
-        queue = false
-        table = false
-        file = false
-    }
-    permissions {
-        read = true
-        write = false
-        delete = false
-        list = false
-        add = false
-        create = false
-        update = false
-        process = false
-    }
+  connection_string = "${azurerm_storage_account.functionStorageAccount.primary_connection_string}"
+  https_only = true
+  formatdate("YYYY-MM-DD", timeadd(timestamp(), "-48h"))
+  expiry = formatdate("YYYY-MM-DD", timeadd(timestamp(), "17520h"))
+
+  resource_types {
+    object = true
+    container = false
+    service = false
+  }
+
+  services {
+    blob = true
+    queue = false
+    table = false
+    file = false
+  }
+
+  permissions {
+    read = true
+    write = false
+    delete = false
+    list = false
+    add = false
+    create = false
+    update = false
+    process = false
+  }
 }
 
 resource "azurerm_function_app" "functionApp" {
@@ -36,10 +39,10 @@ resource "azurerm_function_app" "functionApp" {
   version                   = "beta"
 
   app_settings = {
-      FUNCTIONS_WORKER_RUNTIME = "dotnet"
-      FUNCTION_APP_EDIT_MODE = "readonly"
-      HASH = "${base64encode(filesha256(data.archive_file.functionapp.output_path))}"
-      WEBSITE_RUN_FROM_PACKAGE = "https://${azurerm_storage_account.functionStorageAccount.name}.blob.core.windows.net/${azurerm_storage_container.deployments.name}/${azurerm_storage_blob.appcode.name}${data.azurerm_storage_account_sas.sas.sas}"
+    FUNCTIONS_WORKER_RUNTIME = "dotnet"
+    FUNCTION_APP_EDIT_MODE = "readonly"
+    HASH = "${base64encode(filesha256(data.archive_file.functionapp.output_path))}"
+    WEBSITE_RUN_FROM_PACKAGE = "https://${azurerm_storage_account.functionStorageAccount.name}.blob.core.windows.net/${azurerm_storage_container.deployments.name}/${azurerm_storage_blob.appcode.name}${data.azurerm_storage_account_sas.sas.sas}"
   }
 
   identity {

--- a/cougar/terraform/functionStorageAccount.tf
+++ b/cougar/terraform/functionStorageAccount.tf
@@ -20,15 +20,15 @@ data "archive_file" "functionapp" {
 # Reference: https://adrianhall.github.io/typescript/2019/10/23/terraform-functions/
 
 resource "azurerm_storage_container" "deployments" {
-    name = "function-releases"
-    storage_account_name = azurerm_storage_account.functionStorageAccount.name
-    container_access_type = "private"
+  name = "function-releases"
+  storage_account_name = azurerm_storage_account.functionStorageAccount.name
+  container_access_type = "private"
 }
 
 resource "azurerm_storage_blob" "appcode" {
-    name = data.archive_file.functionapp.output_path
-    storage_account_name = azurerm_storage_account.functionStorageAccount.name
-    storage_container_name = azurerm_storage_container.deployments.name
-    type = "block"
-    source = data.archive_file.functionapp.output_path
+  name = data.archive_file.functionapp.output_path
+  storage_account_name = azurerm_storage_account.functionStorageAccount.name
+  storage_container_name = azurerm_storage_container.deployments.name
+  type = "block"
+  source = data.archive_file.functionapp.output_path
 }


### PR DESCRIPTION
If you don't set the start timestamp to the past, it is possible that the token will be generated for the wrong day due to timezones.

+Formatting.