### PR TITLE
Explicitly set the Cougar runtime version to ~3

### DIFF
--- a/cougar/terraform/functionApp.tf
+++ b/cougar/terraform/functionApp.tf
@@ -36,7 +36,7 @@ resource "azurerm_function_app" "functionApp" {
   resource_group_name       = azurerm_resource_group.cougar.name
   app_service_plan_id       = azurerm_app_service_plan.appServicePlan.id
   storage_connection_string = azurerm_storage_account.functionStorageAccount.primary_connection_string
-  version                   = "beta"
+  version                   = "~3"
 
   app_settings = {
     FUNCTIONS_WORKER_RUNTIME = "dotnet"


### PR DESCRIPTION
The beta ~4 version is broken. From Azure support:

---

Reviewing that app in our system, it looks like your function runtime verion is set to beta, which will cause it to use the latest version of the runtime. This means it would use the 4.x version, which came out recently and is in preview. Is that intentional? It might be worth changing this to 3.x to see if that resolves the issue. You can do that in the portal under general settings. 
 
[Azure Functions runtime versions overview | Microsoft Docs](https://docs.microsoft.com/en-us/azure/azure-functions/functions-versions?tabs=csharp%2Cv4)

---

My reply:

---

Yes, I am still experiencing this issue. The App keys page also hangs indefinitely:

![image](https://user-images.githubusercontent.com/542245/136636598-17659b30-f382-4c56-bfcf-c131d6b49e83.png)

The recent release of the 4.x runtime is a great thing to point out. That said:

1. If downgrading the runtime solves this issue, this is a very poor debugging experience. The error message implies that the service is down and that the user can’t do anything about it. Even if the error message were better, it would be very concerning that any publicly available version of the runtime caused the Azure API calls to completely fail.
2. After setting the runtime to “~3” and restarting the application, the issue persists for several minutes.
3. However, after waiting about 5 minutes, the function is working and the keys are displaying in the UI!